### PR TITLE
Anchors: string start ^ and end $

### DIFF
--- a/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
@@ -1,5 +1,5 @@
-An empty string is the only match: it starts and immediately finishes.
+Uma string vazia é a única correspondência: Ela começa e imediatamente termina.
 
-The task once again demonstrates that anchors are not characters, but tests.
+Esta tarefa demostra novamente que âncoras não são caracteres, mas sim testes.
 
-The string is empty `""`. The engine first matches the `pattern:^` (input start), yes it's there, and then immediately the end `pattern:$`, it's here too. So there's a match.
+A string está vazia `""`. O interpretador primeiro casa o padrão de início da entrada `pattern:^` (que sim, está lá), e então imediatamente o fim da entrada `pattern:$` (que também está). Temos um casamento.

--- a/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
@@ -2,4 +2,4 @@ Uma string vazia é a única correspondência: Ela começa e imediatamente termi
 
 Esta tarefa demostra novamente que âncoras não são caracteres, mas sim testes.
 
-A string está vazia `""`. O interpretador primeiro casa o padrão de início da entrada `pattern:^` (que sim, está lá), e então imediatamente o fim da entrada `pattern:$` (que também está). Temos um casamento.
+A string está vazia `""`. O interpretador primeiro encontra o padrão de início da entrada `pattern:^` (que sim, está lá), e então imediatamente o fim da entrada `pattern:$` (que também está). Temos uma correspondência.

--- a/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
@@ -1,3 +1,3 @@
-# Regexp ^$
+# Regex ^$
 
-Which string matches the pattern `pattern:^$`?
+Qual string casa com o padrão `pattern:^$`?

--- a/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
@@ -1,3 +1,3 @@
-# Regex ^$
+# Expressão Regular ^$
 
 Qual string casa com o padrão `pattern:^$`?

--- a/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
@@ -1,3 +1,3 @@
 # Expressão Regular ^$
 
-Qual string casa com o padrão `pattern:^$`?
+Qual string corresponde ao padrão `pattern:^$`?

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -1,6 +1,6 @@
 # Âncoras: início ^ e fim $ de string
 
-Os caracteres acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um significado especial em expressões regulares. Eles são chamados de "âncoras".
+Os caracterees acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um significado especial em expressões regulares. Eles são chamados de "âncoras".
 
 O acento circunflexo `pattern:^` corresponde ao início da string, e o cifrão `pattern:$` -- ao final.
 
@@ -41,12 +41,12 @@ alert( regexp.test(badInput) ); // false
 
 Nesse exemplo, o casamento com o padrão `pattern:\d\d:\d\d` deve iniciar exatamente após o início da string `pattern:^`, e ser seguido imediatamente pelo fim da string `pattern:$`.
 
-A string inteira deve obedecer exatamente a esse formato. Se houver qualquer desvio ou caracter adicional, o resultado será `false`.
+A string inteira deve obedecer exatamente a esse formato. Se houver qualquer desvio ou caractere adicional, o resultado será `false`.
 
 Âncoras tem um comportamento diferente caso a flag `pattern:m` esteja presente. Veremos isso no próximo artigo.
 
 ```smart header="Âncoras tem \"largura zero\""
 As âncoras `pattern:^` e `pattern:$` são verificações. Elas não possuem largura.
 
-Em outras palavras, elas não casam com um carácter, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.
+Em outras palavras, elas não casam com um caractere, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.
 ```

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -22,7 +22,7 @@ alert( /snow$/.test(str1) ); // true
 
 Nesses casos em particular, poderíamos usar os métodos do objeto string `startsWith/endsWith` em seu lugar. Expressões regulares devem ser usadas para testes mais complexos.
 
-## Testando por casamento completo
+## Casando com uma string inteira
 
 Frequentemente, ambas as âncoras `pattern:^...$` são usadas juntas para verificar se uma string inteira corresponde ao padrão. Para confirmar, por exemplo, se a entrada do usuário está no formato correto.
 

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -4,31 +4,31 @@ Os caracteres acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um si
 
 O acento circunflexo `pattern:^` corresponde ao início da string, e o cifrão `pattern:$` ao final.
 
-Neste exemplo, vamos testar se o texto começa com `Mary`:
+Neste exemplo, vamos testar se o texto começa com `Maria`:
 
 ```js run
-let str1 = "Mary had a little lamb";
-alert( /^Mary/.test(str1) ); // true
+let str1 = "Maria tinha um cordeirinho";
+alert( /^Maria/.test(str1) ); // true
 ```
 
-O padrão `pattern:^Mary` quer dizer: "início da string, e então Mary"
+O padrão `pattern:^Maria` quer dizer: "início da string, e então Maria"
 
-Da mesma maneira, podemos testar se a string termina com `snow` usando `pattern:snow$`:
+Da mesma maneira, podemos testar se a string termina com `neve` usando `pattern:neve$`:
 
 ```js run
-let str1 = "its fleece was white as snow";
-alert( /snow$/.test(str1) ); // true
+let str1 = "Seu velo era branco como a neve";
+alert( /neve$/.test(str1) ); // true
 ```
 
 Nesses casos em particular, poderíamos usar os métodos do objeto string `startsWith/endsWith` em seu lugar. Expressões regulares devem ser usadas para testes mais complexos.
 
-## Casando com uma string inteira
+## Correspondendo com uma string inteira
 
 Frequentemente, ambas as âncoras `pattern:^...$` são usadas juntas para verificar se uma string inteira corresponde ao padrão. Para confirmar, por exemplo, se a entrada do usuário está no formato correto.
 
 Vamos verificar se uma string é um horário no formato `12:34`. Isto é: dois dígitos, seguido de dois pontos (':'), e então mais dois dígitos.
 
-Em termos de expressões regulares, isso fica `pattern:\d\d:\d\d`: 
+Em expressões regulares, isso fica `pattern:\d\d:\d\d`: 
 
 ```js run
 let goodInput = "12:34";

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -1,8 +1,8 @@
 # Âncoras: início ^ e fim $ de string
 
-Os caracterees acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um significado especial em expressões regulares. Eles são chamados de "âncoras".
+Os caracteres acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um significado especial em expressões regulares. Eles são chamados de "âncoras".
 
-O acento circunflexo `pattern:^` corresponde ao início da string, e o cifrão `pattern:$` -- ao final.
+O acento circunflexo `pattern:^` corresponde ao início da string, e o cifrão `pattern:$` ao final.
 
 Neste exemplo, vamos testar se o texto começa com `Mary`:
 
@@ -39,7 +39,7 @@ alert( regexp.test(goodInput) ); // true
 alert( regexp.test(badInput) ); // false
 ```
 
-Nesse exemplo, o casamento com o padrão `pattern:\d\d:\d\d` deve iniciar exatamente após o início da string `pattern:^`, e ser seguido imediatamente pelo fim da string `pattern:$`.
+Nesse exemplo, a correspondência com o padrão `pattern:\d\d:\d\d` deve iniciar exatamente após o início da string `pattern:^`, e ser seguido imediatamente pelo fim da string `pattern:$`.
 
 A string inteira deve obedecer exatamente a esse formato. Se houver qualquer desvio ou caractere adicional, o resultado será `false`.
 
@@ -48,5 +48,5 @@ A string inteira deve obedecer exatamente a esse formato. Se houver qualquer des
 ```smart header="Âncoras tem \"largura zero\""
 As âncoras `pattern:^` e `pattern:$` são verificações. Elas não possuem largura.
 
-Em outras palavras, elas não casam com um caractere, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.
+Em outras palavras, elas não correspondem com um caractere, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.
 ```

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -1,34 +1,34 @@
-# Anchors: string start ^ and end $
+# Âncoras: início ^ e fim $ de string
 
-The caret `pattern:^` and dollar `pattern:$` characters have special meaning in a regexp. They are called "anchors".
+Os caracteres acento circunflexo `pattern:^` e cifrão `pattern:$` possuem um significado especial em expressões regulares. Eles são chamados de "âncoras".
 
-The caret `pattern:^` matches at the beginning of the text, and the dollar `pattern:$` -- at the end.
+O acento circunflexo `pattern:^` corresponde ao início da string, e o cifrão `pattern:$` -- ao final.
 
-For instance, let's test if the text starts with `Mary`:
+Neste exemplo, vamos testar se o texto começa com `Mary`:
 
 ```js run
 let str1 = "Mary had a little lamb";
 alert( /^Mary/.test(str1) ); // true
 ```
 
-The pattern `pattern:^Mary` means: "string start and then Mary".
+O padrão `pattern:^Mary` quer dizer: "início da string, e então Mary"
 
-Similar to this, we can test if the string ends with `snow` using `pattern:snow$`:
+Da mesma maneira, podemos testar se a string termina com `snow` usando `pattern:snow$`:
 
 ```js run
 let str1 = "its fleece was white as snow";
 alert( /snow$/.test(str1) ); // true
 ```
 
-In these particular cases we could use string methods `startsWith/endsWith` instead. Regular expressions should be used for more complex tests.
+Nesses casos em particular, poderíamos usar os métodos do objeto string `startsWith/endsWith` em seu lugar. Expressões regulares devem ser usadas para testes mais complexos.
 
-## Testing for a full match
+## Testando por casamento completo
 
-Both anchors together `pattern:^...$` are often used to test whether or not a string fully matches the pattern. For instance, to check if the user input is in the right format.
+Frequentemente, âmbas as âncoras `pattern:^...$` são usadas juntas para verificar se uma string inteira corresponde ao padrão. Para confirmar, por exemplo, se a entrada do usuário está no formato correto.
 
-Let's check whether or not a string is a time in `12:34` format. That is: two digits, then a colon, and then another two digits.
+Vamos verificar se uma string é um horário no formato `12:34`. Isto é: dois dígitos, seguido de dois pontos (':'), e então mais dois dígitos.
 
-In regular expressions language that's `pattern:\d\d:\d\d`:
+Em termos de expressões regulares, isso fica `pattern:\d\d:\d\d`: 
 
 ```js run
 let goodInput = "12:34";
@@ -39,14 +39,14 @@ alert( regexp.test(goodInput) ); // true
 alert( regexp.test(badInput) ); // false
 ```
 
-Here the match for `pattern:\d\d:\d\d` must start exactly after the beginning of the text `pattern:^`, and the end `pattern:$` must immediately follow.
+Nesse exemplo, o casamento com o padrão `pattern:\d\d:\d\d` deve iniciar exatamente após o início da string `pattern:^`, e ser seguido imediatamente pelo fim da string `pattern:$`.
 
-The whole string must be exactly in this format. If there's any deviation or an extra character, the result is `false`.
+A string inteira deve obedecer exatamente a esse formato. Se houver qualquer desvio ou caracter adicional, o resultado será `false`.
 
-Anchors behave differently if flag `pattern:m` is present. We'll see that in the next article.
+Âncoras tem um comportamento diferente caso a flag `pattern:m` esteja presente. Veremos isso no próximo artigo.
 
-```smart header="Anchors have \"zero width\""
-Anchors `pattern:^` and `pattern:$` are tests. They have zero width.
+```smart header="Âncoras tem \"largura zero\""
+As âncoras `pattern:^` e `pattern:$` são verificações. Elas não possuem largura.
 
-In other words, they do not match a character, but rather force the regexp engine to check the condition (text start/end).
+Em outras palavras, elas não casam com um carácter, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.
 ```

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -24,7 +24,7 @@ Nesses casos em particular, poderíamos usar os métodos do objeto string `start
 
 ## Testando por casamento completo
 
-Frequentemente, âmbas as âncoras `pattern:^...$` são usadas juntas para verificar se uma string inteira corresponde ao padrão. Para confirmar, por exemplo, se a entrada do usuário está no formato correto.
+Frequentemente, ambas as âncoras `pattern:^...$` são usadas juntas para verificar se uma string inteira corresponde ao padrão. Para confirmar, por exemplo, se a entrada do usuário está no formato correto.
 
 Vamos verificar se uma string é um horário no formato `12:34`. Isto é: dois dígitos, seguido de dois pontos (':'), e então mais dois dígitos.
 


### PR DESCRIPTION
Usarei os termos "casar", "casamento" e "correspondência" como tradução para "match" dependendo do contexto, mas quero evitar usar outros termos para evitar confusões.

No artigo como um todo, mas específicamente no trecho

> In other words, they do not match a character, but rather force the regexp engine to check the condition (text start/end).

Faltou com uma explicação simples do que as âncoras realmente representam: uma posição, que foi o que adicionei na minha tradução:

> Em outras palavras, elas não casam com um carácter, mas sim com uma posição, obrigando o interpretador regex a verificar a condição de início ou fim da string.